### PR TITLE
Standardize YAML formatting and add WordPress.org asset updates

### DIFF
--- a/.github/workflows/deploy-dotorg.yml
+++ b/.github/workflows/deploy-dotorg.yml
@@ -1,46 +1,46 @@
 name: Deploy to WordPress.org
 
 on:
-  release:
-    types:
-    - published
+    release:
+        types:
+            - published
 
 jobs:
-  release:
-    name: Publish release
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v7
+    release:
+        name: Publish release
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v7
 
-    - name: Setup Node
-      uses: actions/setup-node@v7
-      with:
-        node-version-file: '.nvmrc'
-        cache: npm
+            - name: Setup Node
+              uses: actions/setup-node@v7
+              with:
+                  node-version-file: '.nvmrc'
+                  cache: npm
 
-    - name: Install dependencies
-      run: npm ci
+            - name: Install dependencies
+              run: npm ci
 
-    - name: Build plugin
-      run: npm run build
+            - name: Build plugin
+              run: npm run build
 
-    - name: Install PHP dependencies
-      uses: ramsey/composer-install@v4
-      with:
-        composer-options: '--prefer-dist --no-scripts --no-dev'
+            - name: Install PHP dependencies
+              uses: ramsey/composer-install@v4
+              with:
+                  composer-options: '--prefer-dist --no-scripts --no-dev'
 
-    - name: WordPress plugin deploy
-      uses: 10up/action-wordpress-plugin-deploy@stable
-      id: deploy
-      with:
-        generate-zip: true
-      env:
-        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
-        SLUG: voice-search
+            - name: WordPress plugin deploy
+              uses: 10up/action-wordpress-plugin-deploy@stable
+              id: deploy
+              with:
+                  generate-zip: true
+              env:
+                  SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+                  SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+                  SLUG: voice-search
 
-    - name: Upload release asset
-      run: gh release upload ${{ github.event.release.tag_name }} ${{ steps.deploy.outputs.zip-path }}
-      env:
-        GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+            - name: Upload release asset
+              run: gh release upload ${{ github.event.release.tag_name }} ${{ steps.deploy.outputs.zip-path }}
+              env:
+                  GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}

--- a/.github/workflows/update-dotorg-assets.yml
+++ b/.github/workflows/update-dotorg-assets.yml
@@ -1,0 +1,24 @@
+name: Update assets on WordPress.org
+
+on:
+    push:
+        branches:
+            - main
+
+jobs:
+    update:
+        name: Update assets
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v7
+
+            - name: Update assets
+              uses: 10up/action-wordpress-plugin-asset-update@stable
+              env:
+                  SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+                  SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+                  IGNORE_OTHER_FILES: true
+                  # This repo has no .wordpress-org directory yet, so only readme.txt
+                  # is synced. Drop this once banner and icon assets are added.
+                  SKIP_ASSETS: true


### PR DESCRIPTION
## Summary
This PR standardizes the YAML indentation in the deployment workflow and adds a new automated workflow to sync plugin assets to WordPress.org on changes to the main branch.

## Key Changes
- **Standardized YAML formatting** in `deploy-dotorg.yml`: Converted all indentation from 2 spaces to 4 spaces for consistency with YAML best practices
- **Added new workflow** `update-dotorg-assets.yml`: Automatically syncs plugin assets (readme.txt) to WordPress.org whenever changes are pushed to the main branch
  - Uses the `10up/action-wordpress-plugin-asset-update@stable` action
  - Currently skips banner and icon assets as they don't exist yet in the repository
  - Includes a note to remove `SKIP_ASSETS` once assets are added

## Implementation Details
- The asset update workflow runs on every push to main, ensuring WordPress.org stays in sync with the repository
- Both workflows use the same SVN credentials stored in repository secrets
- The new workflow is intentionally minimal and focused, with clear documentation about future asset support

https://claude.ai/code/session_013NqAxZqiBuaRKCXvbhMtVs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated updates for WordPress.org plugin listing content when changes are pushed to the main branch.

* **Chores**
  * Standardized deployment workflow formatting without changing its release behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->